### PR TITLE
add a script to obtain a ssl certificate from letsencrypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,19 @@ Pkg.init(); \
 Pkg.add("IJulia");' | julia \
  && mv -i "$HOME/.local/share/jupyter/kernels/julia-0.6" "/usr/local/share/jupyter/kernels/"
 
+###
+
+# Install a script to obtain a ssl certificate from letsencrypt
+
+RUN apt-get update && apt-get install -y curl
+
+COPY letsencrypt-cert.sh /usr/local/sbin/letsencrypt-cert
+
+RUN cd "/usr/local/sbin" \
+ && wget "https://github.com/lukas2511/dehydrated/raw/0be0ab083f290afbc757b8388a80df458ddfd33c/dehydrated" \
+ && echo f1d5ad195669afd315b68af5d6099bdf36a8532bdc0b4a997b1e7139424d7a56 dehydrated | sha256sum -c \
+ && chmod +x "/usr/local/sbin/dehydrated" \
+ && chmod +x "/usr/local/sbin/letsencrypt-cert"
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,34 @@ Once done, you can delete and recreate your CoCalc container.  This will not del
 
 Now visit https://localhost to see your upgraded server.
 
+## Obtain a letsencrypt certificate
+
+The docker image has a script to ease configuration of letsencrypt
+certificates, but it is not automated. Once you have a running
+container:
+
+ * you setup a letsencrypt account by doing (only once)
+```
+docker exec cocalc letsencrypt-cert setup [--test] <DOMAIN> <EMAIL>
+```
+The --test flag configures the account to use the staging letsencrypt
+server which produces certificates signed by fake authority, but otoh
+it doesn't have the small rate limit of the production letsencrypt.
+
+ * you install or renew your certificate (has to be done periodically)
+```
+docker exec cocalc letsencrypt-cert renew
+```
+
+The last step could be automated.
+
+In practice, certificates last for 90 days and if you gave a proper email address you will receive a reminder when the certificate is close to expire.
+
+As it is configured, the last step won't do anything unless your certificate is less than 30 days from expiration, so it is safe to run that once or twice a day. You can use the host cron to repeat it -- the docker container doesn't run cron itself.
+
+In order for this to work, you have to have port 80 exposed and
+accessible directly through `<DOMAIN>`
+
 
 ## Build
 

--- a/letsencrypt-cert.sh
+++ b/letsencrypt-cert.sh
@@ -1,0 +1,91 @@
+#! /bin/bash
+
+progname=$(basename $0)
+
+usage ()
+{
+  echo "$progname setup [--test] <DOMAIN> <EMAIL>"
+  echo "$progname renew"
+  exit 1
+}
+
+CA_PRODUCTION="https://acme-v01.api.letsencrypt.org/directory"
+CA_STAGING="https://acme-staging.api.letsencrypt.org/directory"
+
+BASEDIR="/projects/conf/dehydrated"
+WELLKNOWN="/run/acme-challenge"
+HAPROXY_CRT="/run/haproxy.pem"
+
+case "$1" in
+    renew)
+        if [ ! -f "$BASEDIR/conf" ]
+        then
+            echo "To setup please run"
+            echo
+            echo "    $progname setup [--test] <DOMAIN> <EMAIL>"
+            echo
+            exit 1
+        fi
+        mkdir -p "$WELLKNOWN"
+        chown www-data: "$WELLKNOWN"
+        dehydrated -f "$BASEDIR/conf" -c
+        exit $?
+        ;;
+    setup)
+        shift
+        if [[ "$1" = "--test" ]]
+        then
+            shift
+            CA="\$CA_STAGING"
+        else
+            CA="\$CA_PRODUCTION"
+        fi
+        [[ $# = 2 ]] || usage
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+DOMAIN="$1"
+EMAIL="$2"
+
+mkdir -p "$BASEDIR"
+
+[ -f "$BASEDIR/conf" ] ||
+    cat << EOF > "$BASEDIR/conf"
+CA_PRODUCTION="$CA_PRODUCTION"
+CA_STAGING="$CA_STAGING"
+CA="$CA"
+
+CONTACT_EMAIL="$EMAIL"
+
+BASEDIR="$BASEDIR"
+WELLKNOWN="$WELLKNOWN"
+
+deploy_cert () {
+    if [[ "\$1" = "deploy_cert" ]]
+    then
+        # FULLCHAINFILE + KEYFILE
+        cat "\$5" "\$3" > "$HAPROXY_CRT"
+        cp "$HAPROXY_CRT" "/projects/conf/nopassphrase.pem"
+        service haproxy reload
+    fi
+}
+HOOK=deploy_cert
+EOF
+
+[ -f "$BASEDIR/domains.txt" ] ||
+    echo "$DOMAIN" > "$BASEDIR/domains.txt"
+
+dehydrated -f "$BASEDIR/conf" --register --accept-terms
+
+
+echo To install the certificates you must run
+echo
+echo "    $progname renew"
+echo
+echo and repeat periodically to renew.
+echo
+echo Configuration is in "$BASEDIR/conf" and "$BASEDIR/domains.txt".
+echo For documentation see https://github.com/lukas2511/dehydrated


### PR DESCRIPTION
This uses https://github.com/lukas2511/dehydrated/ as a simple acme client.

Not automated: once you have a running container you must do (assuming your container is named `cocalc`):

 * to setup a letsencrypt account (only once)
```
docker exec cocalc letsencrypt-cert setup [--test] <DOMAIN> <EMAIL>
```

 * to install or renew your certificate (do periodically)
```
docker exec cocalc letsencrypt-cert renew
```

The last step could be automated. In practice, certificates last for 90 days and if you gave a proper email address you will receive a reminder when the certificate is close to expire.

As it is configured, the last step won't do anything unless your certificate is less than 30 days from expiration, so it is safe to run that once or twice a day. You can use the host cron to repeat it -- the docker container doesn't run cron itself.