### PR TITLE
Fix failing build due to obsolete Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 
 MAINTAINER William Stein <wstein@sagemath.com>
 


### PR DESCRIPTION
17.04 reached the EOL about a month ago, so building no longer works:

```
Reading package lists...
[91mW: The repository 'http://security.ubuntu.com/ubuntu zesty-security Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-updates Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-backports Release' does not have a Release file.
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/zesty-security/universe/source/Sources  404  Not Found
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty/universe/source/Sources  404  Not Found
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-updates/universe/source/Sources  404  Not Found
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-backports/universe/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update   && apt-get install -y        software-properties-common        texlive        texlive-latex-extra        texlive-xetex        tmux        flex        bison        libreadline-dev        htop        screen        pandoc        aspell        poppler-utils        net-tools        wget        git        python        python-pip        make        g++        sudo        psmisc        haproxy        nginx        vim        bup        inetutils-ping        lynx        telnet        git        emacs        subversion        ssh        m4        latexmk        libpq5        libpq-dev        build-essential        gfortran        automake        dpkg-dev        libssl-dev        imagemagick        libcairo2-dev        libcurl4-openssl-dev        graphviz        smem        python3-yaml        locales        locales-all' returned a non-zero code: 100
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 100
[0m
```