### PR TITLE
Jupyter widgets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -261,6 +261,10 @@ RUN \
   && dpkg -i rstudio.deb \
   && rm rstudio.deb
 
+# CoCalc Jupyter widgets
+RUN \
+  pip3 install ipyleaflet
+
 CMD /root/run.py
 
 EXPOSE 80 443

--- a/Dockerfile-no-agpl
+++ b/Dockerfile-no-agpl
@@ -248,6 +248,10 @@ RUN \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y x11-apps dbus-x11  \
      xdotool xclip x11-xkb-utils
 
+# CoCalc Jupyter widgets
+RUN \
+  pip3 install ipyleaflet
+
 CMD /root/run.py
 
 EXPOSE 80 443


### PR DESCRIPTION
add Python 3 module needed for CoCalc Jupyter widgets

tested with these containers at UW "monster" server: 
- regular CoCalc b49dccd689df
- no-agpl CoCalc e8f59f867783