### PR TITLE
Add all texlive languages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN \
        texlive-xetex \
        texlive-luatex \
        texlive-bibtex-extra \
+       texlive-lang-all \
        liblog-log4perl-perl
 
 RUN \


### PR DESCRIPTION
This makes the cocalc docker image a lot more useful for working with other languages in latex.

Usage of this could be in the latex package babel, for translation and other language specifics.