### PR TITLE
use vscodium instead of vscode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,12 +250,12 @@ RUN \
 
 # Microsoft's VS Code
 RUN \
-     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
-  && install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/ \
-  && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list' \
+     curl https://repository.vscodium.com/pub.gpg | gpg --dearmor > vscodium.gpg \
+  && install -o root -g root -m 644 vscodium.gpg /etc/apt/trusted.gpg.d/ \
+  && sh -c 'echo "deb [arch=amd64] https://repository.vscodium.com/debs vscodium main" > /etc/apt/sources.list.d/vscodium.list' \
   && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y apt-transport-https \
   && sudo apt-get update \
-  && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y code
+  && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y codium
 
 # RStudio
 RUN \


### PR DESCRIPTION
TL;DR
same experience and same plugins. no default telemetry. true open source binaries. compiled from official code.
more info at https://vscodium.com

vscodium is a free and open source binary distribution of the vscode source code. microsoft provides its own binaries of vscodium, but even if vscodium itself is open source, the official binaries are not, and vscodium is a community effort to fill this gap and provide a true open binary distribution of vscode.

vscodium is 100% compatible with vscode, the plugins are taken from the official repo and the code is actually the same. all the vscodium project does is to provide some custom build scripts to automatically pick the latest vscode version, disable telemetry and proprietary branding and build all the binary files.