### PR TITLE
add R packages needed for ir kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,7 @@ RUN cd /tmp \
 
 # Install R Jupyter Kernel package into R itself (so R kernel works)
 RUN echo "install.packages(c('repr', 'IRdisplay', 'evaluate', 'crayon', 'pbdZMQ', 'httr', 'devtools', 'uuid', 'digest'), repos='http://cran.us.r-project.org'); devtools::install_github('IRkernel/IRkernel')" | sage -R --no-save
+RUN echo "install.packages(c('repr', 'IRdisplay', 'evaluate', 'crayon', 'pbdZMQ', 'httr', 'devtools', 'uuid', 'digest'), repos='http://cran.us.r-project.org'); devtools::install_github('IRkernel/IRkernel')" | R --no-save
 
 
 # Commit to checkout and build.


### PR DESCRIPTION
I added packages needed for Jupyter notebooks to run the ir kernel.

I tried using the packages already installed for ir-sage (to save disk space) by changing the `R_LIBS` ENV setting for the ir kernel, but ended up with an unresolved symbol in `.../lib/R/library/digest/libs/digest.so`.

