### PR TITLE
SendGrid customization during container initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,12 +120,11 @@ RUN    adduser --quiet --shell /bin/bash --gecos "Sage user,101,," --disabled-pa
     && chown -R sage:sage /home/sage/
 
 # make source checkout target, then run the install script
-# see https://github.com/docker/docker/issues/9547 for the sync
 RUN    mkdir -p /usr/local/ \
     && /tmp/scripts/install_sage.sh /usr/local/ master \
     && sync
 
-RUN /tmp/scripts/post_install_sage.sh && rm -rf /tmp/* && sync
+RUN /tmp/scripts/post_install_sage.sh
 
 # Install sage scripts system-wide
 RUN echo "install_scripts('/usr/local/bin/')" | sage
@@ -194,6 +193,10 @@ RUN \
 
 # Install code into Sage
 RUN cd /cocalc/src && sage -pip install --upgrade smc_sagews/
+
+# Update code with environment variables
+# see https://github.com/docker/docker/issues/9547 for the sync
+RUN /tmp/scripts/update_env.sh && rm -rf /tmp/* && sync
 
 RUN echo "umask 077" >> /etc/bash.bashrc
 

--- a/scripts/update_env.sh
+++ b/scripts/update_env.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# update the template and group IDs, if they exist - otherwise, leave them as they are
+sed -i "s/exports.SENDGRID_TEMPLATE_ID = '(.+?)';/exports.SENDGRID_TEMPLATE_ID = '${SENDGRID_TEMPLATE_ID:-\1}';/" /cocalc/src/smc-util/theme.js
+sed -i "s/exports.SENDGRID_ASM_INVITES = (.+?);/exports.SENDGRID_ASM_INVITES = ${SENDGRID_ASM_INVITES:-\1};/" /cocalc/src/smc-util/theme.js
+sed -i "s/exports.SENDGRID_ASM_NEWSLETTER = (.+?);/exports.SENDGRID_ASM_NEWSLETTER = ${SENDGRID_ASM_NEWSLETTER:-\1};/" /cocalc/src/smc-util/theme.js

--- a/scripts/update_env.sh
+++ b/scripts/update_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # update the template and group IDs, if they exist - otherwise, leave them as they are
-sed -i "s/exports.SENDGRID_TEMPLATE_ID = '(.+?)';/exports.SENDGRID_TEMPLATE_ID = '${SENDGRID_TEMPLATE_ID:-\1}';/" /cocalc/src/smc-util/theme.js
-sed -i "s/exports.SENDGRID_ASM_INVITES = (.+?);/exports.SENDGRID_ASM_INVITES = ${SENDGRID_ASM_INVITES:-\1};/" /cocalc/src/smc-util/theme.js
-sed -i "s/exports.SENDGRID_ASM_NEWSLETTER = (.+?);/exports.SENDGRID_ASM_NEWSLETTER = ${SENDGRID_ASM_NEWSLETTER:-\1};/" /cocalc/src/smc-util/theme.js
+sed -i "s/exports\.SENDGRID_TEMPLATE_ID\( *\) = '\(.\+\)';/exports.SENDGRID_TEMPLATE_ID\1 = '${SENDGRID_TEMPLATE_ID:-\2}';/" /cocalc/src/smc-util/theme.js
+sed -i "s/exports\.SENDGRID_ASM_INVITES\( *\) = \(.\+\);/exports.SENDGRID_ASM_INVITES\1 = ${SENDGRID_ASM_INVITES:-\2};/" /cocalc/src/smc-util/theme.js
+sed -i "s/exports\.SENDGRID_ASM_NEWSLETTER\( *\) = \(.\+\);/exports.SENDGRID_ASM_NEWSLETTER\1 = ${SENDGRID_ASM_NEWSLETTER:-\2};/" /cocalc/src/smc-util/theme.js


### PR DESCRIPTION
## Features
Docker containers can now be initialized with SendGrid parameters so that the email functions of CoCalc work as intended.

## Testing
1. Build Docker image
1. Initialize docker container with environment variables: `SENDGRID_TEMPLATE_ID`, `SENDGRID_ASM_INVITES`, and `SENDGRID_ASM_NEWSLETTER` (for testing purposes, these don't have to be real... just use values that are different from the existing ones in `theme.js`)
1. Confirm that `src/smc-util/theme.js` contains the environment variable values you chose

## Remaining SendGrid issues
This PR does not address the initialization of the SendGrid API key - which must still be created manually as follows:
1. `docker exec -it mkdir /cocalc/src/data/secrets`
1. `docker exec -it echo "<SendGrid API key>" > /cocalc/src/data/secrets/sendgrid`

This could also be handled with an environment variable, provided that this approach *does not raise additional security concerns*. In order to do so, these commands could be added to `scripts/update_env.sh`:

`mkdir /cocalc/src/data/secrets`
`echo ${SENDGRID_API_KEY} > /cocalc/src/data/secrets/sendgrid`

## Future Recommendations

Shift all parameters that differ from production CoCalc into a separate file in smc-util, and use a template to populate the values in this file during container initialization. The shell script in this PR should only be a band-aid - using sed to update CoCalc code for docker purposes is not scale-friendly. (I don't know how many other parameters this might include, I only just got started working with my own CoCalc installation... SendGrid is the first hurdle I've encountered.)