### PR TITLE
add support for serving /res files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN \
 # Build and install all deps
 # CRITICAL to install first web, then compute, since compute precompiles all the .js
 # for fast startup, but unfortunately doing so breaks ./install.py all --web, since
-# the .js files laying around somehow mess up cjsx loading. 
+# the .js files laying around somehow mess up cjsx loading.
 RUN \
      cd /cocalc/src \
   && . ./smc-env \

--- a/haproxy.conf
+++ b/haproxy.conf
@@ -59,22 +59,17 @@ frontend https
     acl is_known_user hdr_sub(cookie) has_remember_me=true
     acl is_root_url   path /
     acl is_app        capture.req.uri -m beg /app
- 
+
     http-request redirect code 302 location /app if is_root_url is_known_user
- 
-    # replace "/policies/" with "/static/policies/" at the beginning of any request path.
-    reqrep ^([^\ :]*)\ /policies/(.*)     \1\ /static/policies/\2
+
     # weird detail to know: this only works with the second wildcard match after /app. why?
     reqrep ^([^\ :]*)\ /app(.*) \1\ /static/app.html\2
     # /app must not be cached
     http-response set-header Cache-Control "private, no-cache, max-age=0" if is_app
 
-    # replace "/policies/" with "/static/policies/" at the beginning of any request path.
-    reqrep ^([^\ :]*)\ /policies/(.*)     \1\ /static/policies/\2
-
     reqadd X-Forwarded-Proto:\ https
 
-    acl is_static path_beg /static
+    acl is_static path_beg /static /res
     use_backend static if is_static
 
     acl is_hub path_beg /customize /hub /cookies /blobs /api /invoice /upload /alive /auth /stats /registration /projects /help /settings /api /user_query /user_api

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,9 +3,22 @@ server {
         listen 8080 default_server;
         server_name _;
         index index.html;
+
         location /static/ {
                 rewrite ^/static/(.*) /$1;
                 try_files $uri $uri/ =404;
+        }
+
+        location /res {
+                alias /cocalc/src/webapp-lib/resources/
+                expires "1h";
+                add_header Cache-Control "public";
+
+                # (case-insensitive match) cache those with an explicit semantic version much longer
+                location ~* "^/res/[a-z-]+-\d+\.\d+\.\d+/.*" {
+                     expires "100d";
+                }
+
         }
 
         location / {}  # Needed for access to the index.htm


### PR DESCRIPTION
This is an idea to support https://github.com/sagemathinc/cocalc/pull/4545

I wrote this down without testing it. The idea is to serve these `/res` files from a different location with caching.

Besides that, there are no policy files … and declaring this twice is even less optimal ^^